### PR TITLE
Updating default_spca_params.json keys to match the output of IPFX v1.0

### DIFF
--- a/config/default_spca_params.json
+++ b/config/default_spca_params.json
@@ -35,13 +35,13 @@
         "use_corr": false,
         "range": [0, 120]
     },
-    "spiking_inst_freq": {
+    "inst_freq": {
         "n_components": 6,
         "nonzero_component_list": [300, 275, 225, 275, 250, 225],
         "use_corr": false,
         "range": [120, 420]
     },
-    "spiking_updown": {
+    "spiking_upstroke_downstroke_ratio": {
         "n_components": 3,
         "nonzero_component_list": [300, 275, 250],
         "use_corr": false,

--- a/config/default_spca_params.json
+++ b/config/default_spca_params.json
@@ -29,7 +29,7 @@
         "use_corr": false,
         "range": [0, 140]
     },
-    "spiking_rate": {
+    "psth": {
         "n_components": 6,
         "nonzero_component_list": [95, 80, 100, 70, 70, 70],
         "use_corr": false,


### PR DESCRIPTION
I've changed 3 keys to match the output of  "run_feature_vector_extraction" script from IPFX v1.0.

In addition to the datasets listed in this file, IPFX v1.0 also creates a dataset labeled "subthresh_depol_norm" that is not utilized in this default file.